### PR TITLE
Potential fix for code scanning alert no. 10: DOM text reinterpreted as HTML

### DIFF
--- a/_includes/lazyload.html
+++ b/_includes/lazyload.html
@@ -92,7 +92,7 @@
           if (elem.getAttribute('data-echo-background') !== null) {
             elem.style.backgroundImage = 'url(' + elem.getAttribute('data-echo-background') + ')';
           }
-          else if (elem.src !== (src = elem.getAttribute('data-echo'))) {
+          else if (elem.src !== (src = sanitizeUrl(elem.getAttribute('data-echo')))) {
             elem.src = src;
           }
   
@@ -132,6 +132,14 @@
   
     return echo;
   
+    function sanitizeUrl(url) {
+      try {
+        var parsedUrl = new URL(url, document.baseURI);
+        return parsedUrl.href;
+      } catch (e) {
+        return ''; // Return an empty string for invalid URLs
+      }
+    }
   });
 </script>
 <script>


### PR DESCRIPTION
Potential fix for [https://github.com/guleyc/blog/security/code-scanning/10](https://github.com/guleyc/blog/security/code-scanning/10)

To fix the issue, we need to ensure that the value retrieved from `elem.getAttribute('data-echo')` is sanitized or validated before being assigned to `src` and used to set `elem.src`. A safe approach is to use a function that validates the URL format and ensures it does not contain malicious content. Alternatively, we can encode the value to escape any potentially harmful characters.

The best fix involves:
1. Introducing a utility function to validate or sanitize the URL.
2. Applying this function to the value of `data-echo` before assigning it to `src`.

The changes will be made in the `_includes/lazyload.html` file, specifically around lines 95-96.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
